### PR TITLE
FIX: autoencoder loss nan (about cross entropy weights)

### DIFF
--- a/dataset/carla_dataset.py
+++ b/dataset/carla_dataset.py
@@ -22,7 +22,7 @@ class CarlaDataset(Dataset):
             
         complt_num_per_class= np.asarray([4.16659328e+09, 4.23097440e+07,  3.33326810e+07, 8.17951900e+06, 9.05663000e+05, 3.08392300e+06, 2.35769663e+08, 8.76012450e+07, 1.12863867e+08, 2.98168940e+07, 1.38396550e+07])
         compl_labelweights = complt_num_per_class / np.sum(complt_num_per_class)
-        self.weights = torch.Tensor(np.power(np.amax(compl_labelweights) / compl_labelweights, 1 / 3.0)).cuda()
+        self.weights = torch.Tensor(np.power(np.amax(compl_labelweights) / compl_labelweights, 1 / 3.0))
         
         self.imageset = imageset
 

--- a/dataset/kitti_dataset.py
+++ b/dataset/kitti_dataset.py
@@ -33,16 +33,16 @@ class SemKITTI(data.Dataset):
             split = semkittiyaml['split']['train']
             complt_num_per_class= np.asarray([7632350044, 15783539,  125136, 118809, 646799, 821951, 262978, 283696, 204750, 61688703, 4502961, 44883650, 2269923, 56840218, 15719652, 158442623, 2061623, 36970522, 1151988, 334146])
             compl_labelweights = complt_num_per_class / np.sum(complt_num_per_class)
-            self.weights = torch.Tensor(np.power(np.amax(compl_labelweights) / compl_labelweights, 1 / 3.0)).cuda()
+            self.weights = torch.Tensor(np.power(np.amax(compl_labelweights) / compl_labelweights, 1 / 3.0))
             
         elif imageset == 'val':
             split = semkittiyaml['split']['valid']
-            self.weights = torch.Tensor(np.ones(20) * 3).cuda()
+            self.weights = torch.Tensor(np.ones(20) * 3)
             self.weights[0] = 1
             
         elif imageset == 'test':
             split = semkittiyaml['split']['test']
-            self.weights = torch.Tensor(np.ones(20) * 3).cuda()
+            self.weights = torch.Tensor(np.ones(20) * 3)
             self.weights[0] = 1
         else:
             raise Exception('Split must be train/val/test')

--- a/encoding/train_ae.py
+++ b/encoding/train_ae.py
@@ -40,7 +40,7 @@ class Trainer:
 
         # loss functions
         self.loss_fns = {}
-        self.loss_fns['ce'] = torch.nn.CrossEntropyLoss(weight=self.train_dataset.weights, ignore_index=255)
+        self.loss_fns['ce'] = torch.nn.CrossEntropyLoss(weight=self.train_dataset.weights.cuda(), ignore_index=255)
         self.loss_fns['lovasz'] = None
 
     def train(self):


### PR DESCRIPTION
FIX about #8

I don't know why this phenomenon occurs.

However if you set the class weight in the dataset and send it to cuda(), when iteration is performed in the dataloader, all weights are initialized to 0 and the loss becomes 0.
(In the code below, all weights are become 0)
https://github.com/zoomin-lee/SemCity/blob/b405e58a2d5d1e0202f9347eb54d6b7ce8979fdd/encoding/train_ae.py#L85

I tested it on Python 3.11.9, torch 2.1.0, and Windows.


